### PR TITLE
fix systemd service requirement

### DIFF
--- a/systemd-services/idrs-autoupdate.service
+++ b/systemd-services/idrs-autoupdate.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=IDRS auto update script
-Required=network.target
-After=network.target network-online.target
+Required=network-online.target
+After=network-online.target
 
 [Service]
 User=digicre


### PR DESCRIPTION
どうせ使うディストリUbuntuだろうから不要な変更といえばそれはそうなんですが，世の中には `network.target` を持たないディストリがあって…Centくんって言うんですけど…(重箱の隅つつき的なPRなのでcloseしてくれてもいいです)